### PR TITLE
Stop validation

### DIFF
--- a/src/components/Form/Signup/Username.js
+++ b/src/components/Form/Signup/Username.js
@@ -60,6 +60,7 @@ class Username extends React.Component {
           hasFeedback
         >
           {getFieldDecorator('username', {
+            validateFirst: true,
             rules: [
               { required: true, message: intl.formatMessage({ id: 'error_username_required' }) },
               { validator: validateAccountName },


### PR DESCRIPTION
Stop validating the username if its format is not right. It prevents the app from making an unnecessary api call