### PR TITLE
Fix: exclude the base css in dev environment

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ if (process.env.NODE_ENV !== 'production') { require('./webpack/webpack')(app); 
 
 const hbs = require('hbs');
 
+hbs.registerHelper('baseCss', () => new hbs.SafeString(process.env.NODE_ENV !== 'production' ? '' : '<link rel="stylesheet" href="/css/base.css" type="text/css" media="all"/>'));
 hbs.registerPartials(`${__dirname}/views/partials`);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'hbs');

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -6,7 +6,7 @@
   <meta name="description" content="{{description}}">
   <meta id="viewport" name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <link rel="stylesheet" href="/css/base.css" type="text/css" media="all"/>
+  {{baseCss}}
   <!--[if lt IE 9]><script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
   <script src='//www.google.com/recaptcha/api.js'></script>
 </head>


### PR DESCRIPTION
Add an handlebars helper to include or not the base.css file. This file uses old css in dev mode which can be confusing