### PR TITLE
Set NODE_ENV=production after install and test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:8-alpine
 
-ENV NODE_ENV=production
-
 RUN apk add --update git
 
 WORKDIR /app
 ADD . /app
 RUN yarn install --frozen-lockfile
 RUN yarn run test
+
+ENV NODE_ENV=production
 
 ENTRYPOINT [ "yarn", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ADD . /app
 RUN yarn install --frozen-lockfile
 RUN yarn run test
 
+# prune modules
+RUN yarn install --frozen-lockfile --production
+
 ENV NODE_ENV=production
 
 ENTRYPOINT [ "yarn", "start" ]


### PR DESCRIPTION
This change is supposed to do the trick to run test in Docker.

Fix #115 

I've moved the command `ENV NODE_ENV=production` after `yarn install` and `yarn test` to include `devDependencies` on the install and test. Can you try if it work @jredbeard? I see you are doing similar on condenser. If it work we may want to remove these `devDependencies` after the test are done.