### PR TITLE
Change the way the password is generated

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,10 +1,5 @@
 import { key_utils as keyUtils } from '@steemit/steem-js/lib/auth/ecc';
 
-// https://github.com/steemit/condenser/blob/634c13cd0d2fafa28592e9d5f43589e201198248/app/components/elements/SuggestPassword.jsx#L97
-const createSuggestedPassword = () => {
-  const PASSWORD_LENGTH = 32;
-  const privateKey = keyUtils.get_random_key();
-  return privateKey.toWif().substring(3, 3 + PASSWORD_LENGTH);
-};
+const createSuggestedPassword = () => `P${keyUtils.get_random_key().toWif()}`;
 
 export default createSuggestedPassword;


### PR DESCRIPTION
Fix #178
Generated password follows condenser convention with the P5 prefix

The old code matched this code.
https://github.com/steemit/condenser/blob/634c13cd0d2fafa28592e9d5f43589e201198248/app/components/elements/SuggestPassword.jsx#L97