### PR TITLE
Improve mobile signup experience

### DIFF
--- a/src/components/Form/Signup/ConfirmPhoneNumber.js
+++ b/src/components/Form/Signup/ConfirmPhoneNumber.js
@@ -82,6 +82,7 @@ class ConfirmPhoneNumber extends React.Component {
               prefix={<Icon type="key" />}
               suffix={<a href={undefined} onClick={this.resendCode}><FormattedMessage id="resend" /></a>}
               placeholder={intl.formatMessage({ id: 'confirmation_code' })}
+              type="number"
             />,
           )}
         </Form.Item>

--- a/src/components/Form/Signup/Email.js
+++ b/src/components/Form/Signup/Email.js
@@ -129,6 +129,7 @@ class Email extends React.Component {
             <Input
               prefix={<Icon type="mail" />}
               placeholder={intl.formatMessage({ id: 'email' })}
+              type="email"
             />,
           )}
         </Form.Item>

--- a/src/components/Form/Signup/EmailChinese.js
+++ b/src/components/Form/Signup/EmailChinese.js
@@ -90,6 +90,7 @@ class Email extends React.Component {
             <Input
               prefix={<Icon type="mail" />}
               placeholder={intl.formatMessage({ id: 'email' })}
+              type="email"
             />,
           )}
         </Form.Item>

--- a/src/components/Form/Signup/PhoneNumber.js
+++ b/src/components/Form/Signup/PhoneNumber.js
@@ -115,6 +115,7 @@ class PhoneNumber extends React.Component {
             <Input
               prefix={<Icon type="mobile" />}
               placeholder={intl.formatMessage({ id: 'phone_number' })}
+              type="tel"
             />,
           )}
         </Form.Item>

--- a/src/components/Form/Signup/Username.js
+++ b/src/components/Form/Signup/Username.js
@@ -78,6 +78,10 @@ class Username extends React.Component {
             <Input
               prefix={<Icon type="user" />}
               placeholder={intl.formatMessage({ id: 'username' })}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="none"
+              spellCheck="false"
             />,
           )}
         </Form.Item>


### PR DESCRIPTION
Fix #180 
I used `autocapitalize="none"` according to the documentation below
https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize

On my android phone autocapitalize is not disabled if I use `off` or `none`. There are no other possible values so I leave it to `none` for iPhone compatiblity