### PR TITLE
Im/254/dev query param

### DIFF
--- a/src/components/ConfirmEmail.js
+++ b/src/components/ConfirmEmail.js
@@ -22,8 +22,21 @@ class Index extends Component {
 
     componentWillMount() {
         const { intl } = this.props;
-        const token = this.props.location.query.token;
-        if (!token) {
+        const { token } = this.props.location.query;
+        const debug = this.props.location.query.debug === 'true';
+        if (debug) {
+            this.setState({
+                status: 'success',
+                error: '',
+                // TODO: If this returns true the user is stuck
+                // because no continue button is displayed.
+                // TODO: Find out what consitutes a completed user - e.g. is it approved?
+                completed: false,
+                email: 'foo@bar.com',
+                username: 'foo',
+                token: 'tokenHere',
+            });
+        } else if (!token) {
             this.setState({
                 status: 'error',
                 error: intl.formatMessage({ id: 'error_token_required' }),

--- a/src/components/Form/Signup/ConfirmPhoneNumber.js
+++ b/src/components/Form/Signup/ConfirmPhoneNumber.js
@@ -74,11 +74,15 @@ class ConfirmPhoneNumber extends React.Component {
             });
     };
 
+    devModeSubmit = () => {
+        this.props.onSubmit(true);
+    };
+
     render() {
-        const { form: { getFieldDecorator }, intl, goBack } = this.props;
+        const { form: { getFieldDecorator }, intl, goBack, debug } = this.props;
         return (
             <Form
-                onSubmit={this.handleSubmit}
+                onSubmit={debug ? this.devModeSubmit : this.handleSubmit}
                 className="signup-form confirm-phone"
             >
                 <Form.Item hasFeedback>

--- a/src/components/Form/Signup/Email.js
+++ b/src/components/Form/Signup/Email.js
@@ -116,15 +116,29 @@ class Email extends React.Component {
         });
     };
 
+    devModeSubmit = () => {
+        this.props.onSubmit({ email: 'foo@bar.com' }, 'tokenHere');
+    };
+
     render() {
-        const { form: { getFieldDecorator }, intl, email, goBack } = this.props;
+        const {
+            form: { getFieldDecorator },
+            intl,
+            email,
+            goBack,
+            debug,
+        } = this.props;
         return (
             <Form
                 onSubmit={e => {
                     e.preventDefault();
                     if (this.state.submitting) return;
-                    this.setState({ submitting: true });
-                    this.executeRecaptchaAndSubmit();
+                    if (debug) {
+                        this.devModeSubmit();
+                    } else {
+                        this.setState({ submitting: true });
+                        this.executeRecaptchaAndSubmit();
+                    }
                 }}
                 className="signup-form"
             >

--- a/src/components/Form/Signup/EmailChinese.js
+++ b/src/components/Form/Signup/EmailChinese.js
@@ -70,15 +70,29 @@ class Email extends React.Component {
         });
     };
 
+    devModeSubmit = () => {
+        this.props.onSubmit({ email: 'foo@bar.com' }, 'tokenHere');
+    };
+
     render() {
-        const { form: { getFieldDecorator }, intl, email, goBack } = this.props;
+        const {
+            form: { getFieldDecorator },
+            intl,
+            email,
+            goBack,
+            debug,
+        } = this.props;
         return (
             <Form
                 onSubmit={e => {
                     e.preventDefault();
                     if (this.state.submitting) return;
-                    this.setState({ submitting: true });
-                    this.handleSubmit();
+                    if (debug) {
+                        this.devModeSubmit();
+                    } else {
+                        this.setState({ submitting: true });
+                        this.executeRecaptchaAndSubmit();
+                    }
                 }}
                 className="signup-form"
             >

--- a/src/components/Form/Signup/PhoneNumber.js
+++ b/src/components/Form/Signup/PhoneNumber.js
@@ -90,12 +90,24 @@ class PhoneNumber extends React.Component {
         });
     };
 
+    devModeSubmit = () => {
+        this.props.onSubmit(
+            {
+                phoneNumber: '+13136139666',
+                phoneNumberFormatted: '+13136139666',
+                prefix: '+1',
+            },
+            'tokenHere'
+        );
+    };
+
     render() {
         const {
             form: { getFieldDecorator },
             intl,
             prefix,
             phoneNumber,
+            debug,
         } = this.props;
 
         const prefixSelector = getFieldDecorator('prefix', {
@@ -131,7 +143,10 @@ class PhoneNumber extends React.Component {
             </Select>
         );
         return (
-            <Form onSubmit={this.handleSubmit} className="signup-form">
+            <Form
+                onSubmit={debug ? this.devModeSubmit : this.handleSubmit}
+                className="signup-form"
+            >
                 <Form.Item>{prefixSelector}</Form.Item>
                 <Form.Item>
                     {getFieldDecorator('phoneNumber', {

--- a/src/components/Form/Signup/Username.js
+++ b/src/components/Form/Signup/Username.js
@@ -66,6 +66,7 @@ class Username extends React.Component {
             intl,
             username,
             origin,
+            debug,
         } = this.props;
         return (
             <Form onSubmit={this.handleSubmit} className="signup-form">
@@ -80,8 +81,14 @@ class Username extends React.Component {
                                     id: 'error_username_required',
                                 }),
                             },
-                            { validator: this.validateAccountNameIntl },
-                            { validator: this.validateUsername },
+                            {
+                                validator:
+                                    debug !== 'true' &&
+                                    this.validateAccountNameIntl,
+                            },
+                            {
+                                validator: !debug && this.validateUsername,
+                            },
                         ],
                         initialValue: username,
                     })(

--- a/src/components/Signup.js
+++ b/src/components/Signup.js
@@ -36,6 +36,7 @@ class Signup extends Component {
                 email: PropTypes.string,
                 token: PropTypes.string,
                 ref: PropTypes.string,
+                debug: PropTypes.string,
             }),
         }),
         locale: PropTypes.string.isRequired,
@@ -60,20 +61,23 @@ class Signup extends Component {
             countryCode: '',
             prefix: '',
             completed: false,
+            debug: props.location.query.debug === 'true',
         };
     }
 
     componentWillMount() {
-        fetch('/api/guess_country')
-            .then(checkStatus)
-            .then(parseJSON)
-            .then(data => {
-                if (data.location) {
-                    this.setState({
-                        countryCode: data.location.country.iso_code,
-                    });
-                }
-            });
+        if (!this.state.debug) {
+            fetch('/api/guess_country')
+                .then(checkStatus)
+                .then(parseJSON)
+                .then(data => {
+                    if (data.location) {
+                        this.setState({
+                            countryCode: data.location.country.iso_code,
+                        });
+                    }
+                });
+        }
     }
 
     initStep = () => {
@@ -255,6 +259,7 @@ class Signup extends Component {
                                     username={username}
                                     email={email}
                                     origin={ref}
+                                    debug
                                 />
                             </div>
                         )}
@@ -272,6 +277,7 @@ class Signup extends Component {
                                         username={username}
                                         email={email}
                                         goBack={this.goBack}
+                                        debug
                                     />
                                 )}
                                 {countryCode === 'CN' && (
@@ -280,6 +286,7 @@ class Signup extends Component {
                                         username={username}
                                         email={email}
                                         goBack={this.goBack}
+                                        debug
                                     />
                                 )}
                             </div>
@@ -298,6 +305,7 @@ class Signup extends Component {
                                     countryCode={countryCode}
                                     prefix={prefix}
                                     phoneNumber={phoneNumber}
+                                    debug
                                 />
                             </div>
                         )}
@@ -337,6 +345,7 @@ class Signup extends Component {
                                     phoneNumber={phoneNumber}
                                     prefix={prefix}
                                     goBack={this.goBack}
+                                    debug
                                 />
                             </div>
                         )}

--- a/src/containers/app.js
+++ b/src/containers/app.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { LocaleProvider } from 'antd';
 import { IntlProvider } from 'react-intl';
 import { bindActionCreators } from 'redux';
@@ -28,6 +29,15 @@ export default class App extends Component {
         children: React.PropTypes.element.isRequired,
         locale: React.PropTypes.string.isRequired,
         setLocale: React.PropTypes.func.isRequired,
+        location: PropTypes.shape({
+            query: PropTypes.shape({
+                debug: PropTypes.string,
+            }),
+        }),
+    };
+
+    static defaultProps = {
+        location: null,
     };
 
     componentWillMount() {
@@ -37,7 +47,7 @@ export default class App extends Component {
     }
 
     render() {
-        const { locale, children } = this.props;
+        const { locale, children, location: { query: { debug } } } = this.props;
         let defaultLocale = locale;
         if (locale === 'auto') {
             defaultLocale = getAvailableLocale(locale);
@@ -47,7 +57,14 @@ export default class App extends Component {
         return (
             <IntlProvider locale={defaultLocale} messages={translations}>
                 <LocaleProvider locale={antdLocale}>
-                    <div className="main">{children}</div>
+                    <div className="main">
+                        {children}
+                        {debug && (
+                            <div className="debug">
+                                <h1>☁ ▅▒░☼‿☼░▒▅ ☁ DEBUG MODE!</h1>
+                            </div>
+                        )}
+                    </div>
                 </LocaleProvider>
             </IntlProvider>
         );

--- a/src/styles/theme.less
+++ b/src/styles/theme.less
@@ -23,3 +23,11 @@
     font-size: 14px;
   }
 }
+
+.debug {
+  position: absolute;
+  top: 0;
+  h1 {
+    color: deeppink;
+  }
+}


### PR DESCRIPTION
fixes #254 
supercedes #267 

This is a more elegant way of doing things and carries through to prod.
Basically, for whatever route, if the query param `debug=true` is present, you'll be able to skip all external calls.

For clarity a 'debug mode' flag is also displayed.

got to `/?debug=true`, when you can go no further go to `/confirm-email?debug=true`, when you can go no further go to `/create-account?debug=true`. :-)

# Demo:
## 1
![step1](https://user-images.githubusercontent.com/3374538/38220131-4adc42dc-369e-11e8-98db-042c70920f49.gif)
## 2
![step2](https://user-images.githubusercontent.com/3374538/38220135-4e507316-369e-11e8-8f31-3187273bf792.gif)
## 3
![step3](https://user-images.githubusercontent.com/3374538/38220140-51aa4348-369e-11e8-9928-bdcdd68e8fcc.gif)



