### PR TITLE
Do not truncate passwords during signup

### DIFF
--- a/src/components/Form/CreateAccount/Password.js
+++ b/src/components/Form/CreateAccount/Password.js
@@ -91,26 +91,26 @@ class Password extends React.Component {
                         ],
                         initialValue: init ? createSuggestedPassword() : '',
                     })(
-                        <Input
-                            prefix={<Icon type="lock" size="large" />}
-                            suffix={
-                                init && (
-                                    <a
-                                        href={undefined}
-                                        onClick={() => {
-                                            this.copyToClipboard(
-                                                getFieldValue('password')
-                                            );
-                                        }}
-                                    >
-                                        <FormattedMessage id="copy" />
-                                    </a>
-                                )
-                            }
+                        <Input.TextArea
                             placeholder={intl.formatMessage({ id: 'password' })}
                             id="password"
                             readOnly={init}
+                            minRows={1}
+                            maxRows={2}
                         />
+                    )}
+                </Form.Item>
+                <Form.Item>
+                    {init && (
+                        <a
+                            href={undefined}
+                            className="new-password"
+                            onClick={() => {
+                                this.copyToClipboard(getFieldValue('password'));
+                            }}
+                        >
+                            <FormattedMessage id="copy_password" />
+                        </a>
                     )}
                 </Form.Item>
                 {init && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,7 +9,7 @@
     "confirm_password": "Please enter your password to confirm it.",
     "confirmation_code": "Confirmation code",
     "continue": "Continue",
-    "copy": "Copy",
+    "copy_password": "Copy Password",
     "country_code_select": "Select your country code",
     "edit": "Edit",
     "email": "Email",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -11,7 +11,7 @@
         "Veuillez saisir votre mot de passe afin de le confirmer.",
     "confirmation_code": "Code de confirmation",
     "continue": "Continuer",
-    "copy": "Copier",
+    "copy_password": "Copier mot de passe",
     "country_code_select": "Sélectionnez votre pays",
     "edit": "Éditer",
     "email": "Email",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -8,7 +8,7 @@
     "confirm_password": "请输入密码以确认",
     "confirmation_code": "验证码",
     "continue": "继续",
-    "copy": "复制",
+    "copy_password": "复制密码",
     "country_code_select": "选择地区",
     "edit": "编辑",
     "email": "E-mail",


### PR DESCRIPTION
Closes #266.

Screenshot of proposed changes:

![screen shot 2018-04-06 at 3 39 50 pm](https://user-images.githubusercontent.com/2797238/38443815-927a05a4-39b2-11e8-877f-668fb081e9f0.png)

Unfortunately we lose the prefix and suffix properties, hence the missing lock and the moved copy button, due to the change to `Input.TextArea`.