### PR TITLE
Manually run prettier & fix weird lint race

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,7 @@
   },
   "lint-staged": {
     "src/**/*.js*": [
-      "prettier --write",
-      "git add"
+      "prettier -l"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "./bin/www",
     "start-dev": "nodemon --ignore src ./bin/www | bunyan -o short",
     "test": "eslint \"src/**/*.js\" \"routes/**/*.js\" \"helpers/**/*.js\" && nsp check --output summary",
-    "lint": "eslint --fix \"src/**/*.js\" \"routes/**/*.js\" \"helpers/**/*.js\"",
+    "lint": "prettier --write --config .prettierrc  \"src/**/*.js*\" \"routes/**/*.js\" \"helpers/**/*.js\"&& eslint --fix \"src/**/*.js\" \"routes/**/*.js\" \"helpers/**/*.js\"",
     "build": "webpack -p --config webpack/webpack.prod.config.js",
     "build-dev": "webpack --progress -p --config webpack/webpack.config.js",
     "precommit": "lint-staged"

--- a/src/components/CreateAccount.js
+++ b/src/components/CreateAccount.js
@@ -205,6 +205,8 @@ class CreateAccount extends Component {
             reservedUsername,
             password,
         } = this.state;
+        const isPasswordOrConfirmStep =
+            step === 'password' || step === 'password_confirm';
         const { setLocale, locale } = this.props;
         return (
             <div className="Signup_main">
@@ -394,8 +396,7 @@ class CreateAccount extends Component {
                                 aria-label="signup-username"
                             />
                         )}
-                        {(step === 'password' ||
-                            step === 'password_confirm') && (
+                        {isPasswordOrConfirmStep && (
                             <object
                                 data="img/signup-password.svg"
                                 type="image/svg+xml"


### PR DESCRIPTION
eslint & prettier disagreed about an indentation issue, and this is a workaround for that

also, johan & i were chatting about it and decided that it's better to do the `eslint` and `prettier` outside of the precommit -- this requires devs to run `yarn lint` manually, which gives an opportunity to avoid these tools from munging the code you just wrote :)