### PR TITLE
Add more search filters

### DIFF
--- a/admin/src/components/signup-list.tsx
+++ b/admin/src/components/signup-list.tsx
@@ -38,7 +38,7 @@ enum TableAction {
 
 const ITEMS_PER_PAGE = 50
 
-const SEARCH_FILTER_PATTERN = /(\w+):([^ ]+)/g
+const SEARCH_FILTER_PATTERN = /(!?\w+):([^ ]+)/g
 
 function parseSearchFilter(filter: string) {
   const filters: SignupListFilter[] = []

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -169,7 +169,7 @@ addHandler('/list_signups', async req => {
         query.offset = offset;
     }
     if (Array.isArray(filters) && filters.length > 0) {
-        const { or, eq, ne, like, notLike, and, gte, lte } = Sequelize.Op;
+        const { or, eq, ne, like, notLike, and, gte, lte, regexp, notRegexp} = Sequelize.Op;
         const andList = [];
         for (const filter of filters) {
             // eslint-disable-line
@@ -182,6 +182,7 @@ addHandler('/list_signups', async req => {
             }
             const nLike = negate ? notLike : like
             const nEq = negate ? ne :  eq
+            const nRegexp = negate ? notRegexp : regexp
             switch (name) {
                 case 'text':
                     andList.push({
@@ -198,6 +199,26 @@ addHandler('/list_signups', async req => {
                     break;
                 case 'ip':
                     andList.push({ ip: { [nEq]: value } });
+                    break;
+                case 'username':
+                    andList.push({ username: { [nEq]: value } });
+                    break;
+                case 'phone':
+                case 'phone_number':
+                    andList.push({ phone_number: { [nEq]: value } });
+                    break;
+                case 'email':
+                    andList.push({ email: { [nEq]: value } });
+                    break;
+                case 'username_re':
+                    andList.push({ username: { [nRegexp]: value } });
+                    break;
+                case 'email_re':
+                    andList.push({ email: { [nRegexp]: value } });
+                    break;
+                case 'phone_re':
+                case 'phone_number_re':
+                    andList.push({ phone_number: { [nRegexp]: value } });
                     break;
                 case 'from':
                     andList.push({ created_at: { [gte]: new Date(value) } });


### PR DESCRIPTION
Supersedes #338 
Closes #333 
Closes https://github.com/steemit/steempunks/issues/340

New filters added:

 * `username` – exact username match
 * `email` – exact email match
 * `phone` – exact phone number match
 * `username_re` – username regex
 * `email_re` – email regex
 * `phone_re` – phone regex

Also added the ability to negate filters by appending `!`, e.g. `!email:goodboy@example.com` or `!email_re:@google.com$`. The full-text search can also be negated by using the `text` filter, e.g. `!text:GTX 1080` will exclude any user who has the string `GTX 1080` anywhere in their fingerprint, email, phone or username.

