### PR TITLE
disallow email aliases that match existing emails during registration

### DIFF
--- a/db/migrations/004.normalize-emails.js
+++ b/db/migrations/004.normalize-emails.js
@@ -1,5 +1,7 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
+    // Manual migration step:
+    // UPDATE users SET email_normalized = LOWER(CONCAT(REPLACE(SUBSTRING_INDEX(SUBSTRING_INDEX(email, '@', 1), '+', 1), '.', ''), '@', SUBSTRING_INDEX(email, '@', -1)));
     await queryInterface.addColumn('users', 'email_normalized', {
       type: Sequelize.STRING,
       allowNull: true,

--- a/db/migrations/004.normalize-emails.js
+++ b/db/migrations/004.normalize-emails.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('users', 'email_normalized', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('users', 'email_normalized');
+  },
+};

--- a/helpers/database.js
+++ b/helpers/database.js
@@ -5,6 +5,7 @@ const { Sequelize } = db;
 const { Op } = Sequelize;
 
 const { ApiError } = require('./errortypes');
+const { normalizeEmail } = require('./validator');
 
 /**
  * Throws if user or ip exceeds number of allowed actions within time period.
@@ -30,9 +31,11 @@ async function actionLimit(ip, user_id = null) {
 }
 
 async function emailIsInUse(email) {
+    // Normalize email
+    const normalized = normalizeEmail(email);
     const userCount = await db.users.count({
         where: {
-            email,
+            email_normalized: normalized,
             email_is_verified: true,
         },
     });

--- a/helpers/validator.js
+++ b/helpers/validator.js
@@ -147,7 +147,7 @@ const normalizeEmail = email => {
     const username = email.split('@')[0].replace(/\+.*/, '');
     const domain = email.split('@')[1];
 
-    if (gmailDomains.indexOf(domain) > -1) {
+    if (gmailDomains.includes(domain)) {
         return `${username.replace(/\./g, '')}@gmail.com`;
     }
 

--- a/helpers/validator.js
+++ b/helpers/validator.js
@@ -140,9 +140,17 @@ const validateEmailDomain = (rule, value, callback) => {
     }
 };
 
+// Remove dots and plus sign aliases from an email address.
+const normalizeEmail = email =>
+    `${email
+        .split('@')[0]
+        .replace(/\./g, '')
+        .replace(/\+.*/, '')}@${email.split('@')[1]}`;
+
 module.exports = {
     accountNotExist,
     accountNameIsValid,
     validateEmail,
     validateEmailDomain,
+    normalizeEmail,
 };

--- a/helpers/validator.js
+++ b/helpers/validator.js
@@ -140,12 +140,19 @@ const validateEmailDomain = (rule, value, callback) => {
     }
 };
 
-// Remove dots and plus sign aliases from an email address.
-const normalizeEmail = email =>
-    `${email
-        .split('@')[0]
-        .replace(/\./g, '')
-        .replace(/\+.*/, '')}@${email.split('@')[1]}`;
+// Remove dots (if gmail) and plus sign aliases from an email address.
+const normalizeEmail = email => {
+    const gmailDomains = ['gmail.com', 'googlemail.com'];
+
+    const username = email.split('@')[0].replace(/\+.*/, '');
+    const domain = email.split('@')[1];
+
+    if (gmailDomains.indexOf(domain) > -1) {
+        return `${username.replace(/\./g, '')}@gmail.com`;
+    }
+
+    return `${username}@${domain}`;
+};
 
 module.exports = {
     accountNotExist,

--- a/helpers/validator.js
+++ b/helpers/validator.js
@@ -144,8 +144,11 @@ const validateEmailDomain = (rule, value, callback) => {
 const normalizeEmail = email => {
     const gmailDomains = ['gmail.com', 'googlemail.com'];
 
-    const username = email.split('@')[0].replace(/\+.*/, '');
-    const domain = email.split('@')[1];
+    const username = email
+        .split('@')[0]
+        .replace(/\+.*/, '')
+        .toLowerCase();
+    const domain = email.split('@')[1].toLowerCase();
 
     if (gmailDomains.includes(domain)) {
         return `${username.replace(/\./g, '')}@gmail.com`;

--- a/helpers/validator.test.js
+++ b/helpers/validator.test.js
@@ -1,0 +1,16 @@
+const { normalizeEmail } = require('./validator');
+
+describe('normalizeEmail', () => {
+    it('should normalize emails', () => {
+        const emails = {
+            '555@ccc.com': '555@ccc.com',
+            '555+foo@ccc.com': '555@ccc.com',
+            '66.6@ccc.com': '666@ccc.com',
+            '6...6......6@ccc.com': '666@ccc.com',
+            '66.6+foo@ccc.com': '666@ccc.com',
+        };
+        Object.keys(emails).forEach(messy => {
+            expect(normalizeEmail(messy)).toEqual(emails[messy]);
+        });
+    });
+});

--- a/helpers/validator.test.js
+++ b/helpers/validator.test.js
@@ -5,9 +5,10 @@ describe('normalizeEmail', () => {
         const emails = {
             '555@ccc.com': '555@ccc.com',
             '555+foo@ccc.com': '555@ccc.com',
-            '66.6@ccc.com': '666@ccc.com',
-            '6...6......6@ccc.com': '666@ccc.com',
-            '66.6+foo@ccc.com': '666@ccc.com',
+            '66.6@gmail.com': '666@gmail.com',
+            '66.6@googlemail.com': '666@gmail.com',
+            '6...6......6@ccc.com': '6...6......6@ccc.com',
+            '66.6+foo@ccc.com': '66.6@ccc.com',
         };
         Object.keys(emails).forEach(messy => {
             expect(normalizeEmail(messy)).toEqual(emails[messy]);

--- a/helpers/validator.test.js
+++ b/helpers/validator.test.js
@@ -3,10 +3,10 @@ const { normalizeEmail } = require('./validator');
 describe('normalizeEmail', () => {
     it('should normalize emails', () => {
         const emails = {
-            '555@ccc.com': '555@ccc.com',
+            '555@cCc.com': '555@ccc.com',
             '555+foo@ccc.com': '555@ccc.com',
-            '66.6@gmail.com': '666@gmail.com',
-            '66.6@googlemail.com': '666@gmail.com',
+            '66.6@Gmail.com': '666@gmail.com',
+            '66.6@googleMail.com': '666@gmail.com',
             '6...6......6@ccc.com': '6...6......6@ccc.com',
             '66.6+foo@ccc.com': '66.6@ccc.com',
         };

--- a/routes/apiHandlers.js
+++ b/routes/apiHandlers.js
@@ -10,7 +10,7 @@ const badDomains = require('../bad-domains');
 const services = require('../helpers/services');
 const database = require('../helpers/database');
 const { generateTrackingId } = require('../helpers/stepLogger');
-const { accountNameIsValid } = require('../helpers/validator');
+const { accountNameIsValid, normalizeEmail } = require('../helpers/validator');
 const { ApiError } = require('../helpers/errortypes.js');
 
 /**
@@ -180,6 +180,7 @@ async function handleRequestEmail(
     } else {
         const newUser = await database.createUser({
             email,
+            email_normalized: normalizeEmail(email),
             email_is_verified: false,
             last_attempt_verify_email: null,
             phone_number: '',


### PR DESCRIPTION
closes steemit/steempunks#245

gmail and other providers allow users to use email aliases like as.df+asdf@asdf.com which will resolve to asdf@asdf.com

this PR requires a manual db migration that does not fit into sequelize's framework:

```mysql
UPDATE users SET email_normalized = LOWER(CONCAT(REPLACE(SUBSTRING_INDEX(SUBSTRING_INDEX(email, '@', 1), '+', 1), '.', ''), '@', SUBSTRING_INDEX(email, '@', -1)));
```

(to be run after `yarn exec -- sequelize db:migrate` which will add the new col)