### PR TITLE
fix regression in admin search regex

### DIFF
--- a/admin/src/components/signup-list.tsx
+++ b/admin/src/components/signup-list.tsx
@@ -38,7 +38,7 @@ enum TableAction {
 
 const ITEMS_PER_PAGE = 50
 
-const SEARCH_FILTER_PATTERN = /(!?[a-z.]*):([^ ]+)/g
+const SEARCH_FILTER_PATTERN = /(!?[\w.]*):([^ ]+)/g
 
 function parseSearchFilter(filter: string) {
   const filters: SignupListFilter[] = []


### PR DESCRIPTION
Accidentally removed _ from admin search, required for `email_re` search key among others.