### PR TITLE
quickly disable account creation step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,4 @@ DEFAULT_REDIRECT_URI=https://steemit.com/login.html#account={{username}}
 GOOGLE_CLIENT_ID=XXX
 GOOGLE_AUTHORIZED_DOMAINS=steemit.com
 INFLUXDB_URL=http://influx.db:8080
+REACT_DISABLE_ACCOUNT_CREATION=false

--- a/helpers/getClientConfig.js
+++ b/helpers/getClientConfig.js
@@ -9,6 +9,7 @@ function getClientConfig() {
         'RECAPTCHA_SITE_KEY',
         'STEEMJS_URL',
         'DEFAULT_REDIRECT_URI',
+        'REACT_DISABLE_ACCOUNT_CREATION',
     ];
 
     return JSON.stringify(

--- a/routes/apiHandlers.js
+++ b/routes/apiHandlers.js
@@ -555,11 +555,7 @@ async function handleConfirmAccount(token) {
  */
 async function handleCreateAccount(req) {
     // Do not allow account creations if REACT_DISABLE_ACCOUNT_CREATION is set to true
-    if (
-        true ||
-        /* todo: env var in the future */ process.env
-            .REACT_DISABLE_ACCOUNT_CREATION === 'true'
-    ) {
+    if (process.env.REACT_DISABLE_ACCOUNT_CREATION === 'true') {
         throw new ApiError({
             type: 'Account creation temporarily disabled',
             status: 503,

--- a/routes/apiHandlers.js
+++ b/routes/apiHandlers.js
@@ -554,6 +554,18 @@ async function handleConfirmAccount(token) {
  * Remove the user information from our database
  */
 async function handleCreateAccount(req) {
+    // Do not allow account creations if REACT_DISABLE_ACCOUNT_CREATION is set to true
+    if (
+        true ||
+        /* todo: env var in the future */ process.env
+            .REACT_DISABLE_ACCOUNT_CREATION === 'true'
+    ) {
+        throw new ApiError({
+            type: 'Account creation temporarily disabled',
+            status: 503,
+        });
+    }
+
     const { username, public_keys, token, email } = req.body; // eslint-disable-line camelcase
     const decoded = verifyToken(token, 'create_account');
     if (!username) {

--- a/src/components/CreateAccount.js
+++ b/src/components/CreateAccount.js
@@ -188,11 +188,7 @@ class CreateAccount extends Component {
     };
 
     render() {
-        if (
-            true ||
-            /* todo: add env var */ process.env
-                .REACT_DISABLE_ACCOUNT_CREATION === 'true'
-        ) {
+        if (config.REACT_DISABLE_ACCOUNT_CREATION === 'true') {
             return <div>Signups temporarily disabled</div>;
         }
 

--- a/src/components/CreateAccount.js
+++ b/src/components/CreateAccount.js
@@ -188,7 +188,7 @@ class CreateAccount extends Component {
     };
 
     render() {
-        if (config.REACT_DISABLE_ACCOUNT_CREATION === 'true') {
+        if (window.config.REACT_DISABLE_ACCOUNT_CREATION === 'true') {
             return <div>Signups temporarily disabled</div>;
         }
 

--- a/src/components/CreateAccount.js
+++ b/src/components/CreateAccount.js
@@ -188,6 +188,14 @@ class CreateAccount extends Component {
     };
 
     render() {
+        if (
+            true ||
+            /* todo: add env var */ process.env
+                .REACT_DISABLE_ACCOUNT_CREATION === 'true'
+        ) {
+            return <div>Signups temporarily disabled</div>;
+        }
+
         const {
             step,
             stepNumber,


### PR DESCRIPTION
-todo: env var does not work in frontend build; need to fix in the future.- fixed

this PR disables the endpoint, and displays a message to users who try to create their account via the emailed link.

to disable account creation, set env var `REACT_DISABLE_ACCOUNT_CREATION` to `true`.