### PR TITLE
Add Steem.Ninja to paid signup model.

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -4,6 +4,7 @@ const CHECKPOINTS = {
     paid_signup_clicked_blocktrades: 'paid_signup_clicked_blocktrades',
     paid_signup_clicked_anonsteem: 'paid_signup_clicked_anonsteem',
     paid_signup_clicked_steemconnect: 'paid_signup_clicked_steemconnect',
+    paid_signup_clicked_steemninja: 'paid_signup_clicked_steemconnect',
     free_signup_chosen: 'free_signup_chosen',
     username_chosen: 'username_chosen',
     email_submitted: 'email_submitted',
@@ -35,6 +36,10 @@ const checkpoints = [
     {
         human: 'Clicked steemconnect',
         symbol: CHECKPOINTS.paid_signup_clicked_steemconnect,
+    },
+    {
+        human: 'Clicked steemninja',
+        symbol: CHECKPOINTS.paid_signup_clicked_steemninja,
     },
     {
         human: 'Pressed "Sign up for free"',

--- a/constants.js
+++ b/constants.js
@@ -4,7 +4,7 @@ const CHECKPOINTS = {
     paid_signup_clicked_blocktrades: 'paid_signup_clicked_blocktrades',
     paid_signup_clicked_anonsteem: 'paid_signup_clicked_anonsteem',
     paid_signup_clicked_steemconnect: 'paid_signup_clicked_steemconnect',
-    paid_signup_clicked_steemninja: 'paid_signup_clicked_steemconnect',
+    paid_signup_clicked_steemninja: 'paid_signup_clicked_steemninja',
     free_signup_chosen: 'free_signup_chosen',
     username_chosen: 'username_chosen',
     email_submitted: 'email_submitted',

--- a/src/components/Form/Signup/SignupOptions.js
+++ b/src/components/Form/Signup/SignupOptions.js
@@ -134,6 +134,24 @@ const SignupOptions = ({
                 <p>
                     <FormattedMessage id="signup_options_steemconnect" />
                 </p>
+                <a
+                    className="external-link"
+                    href="https://account.steem.ninja"
+                    onClick={() => {
+                        logCheckpoint(
+                            CHECKPOINTS.paid_signup_clicked_steemninja
+                        );
+                    }}
+                >
+                    <Button type="primary" ghost htmlType="button">
+                        Steem.Ninja
+                        <Icon type="link" />
+                    </Button>
+                </a>
+                <p>
+                    <FormattedMessage id="signup_options_steemninja" />
+                </p>
+
                 <hr />
                 <p className="modal-disclaimer">
                     <FormattedMessage id="signup_options_disclaimer" />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -142,6 +142,8 @@
         "A third-party tool that accepts Bitcoin, Litecoin and STEEM. AnonSteem also charges it's own a small fee.",
     "signup_options_steemconnect":
         "Try this option if you already have a Steem account and want to pay to set up a new account for yourself or a friend.",
+    "signup_options_steemninja":
+        "A third-party tool that accepts credit card payments. Steem.Ninja also charges its own small fee.",
     "signup_options_disclaimer":
         "Note: Steemit, Inc does not receive any money from paid accounts.",
     "signup_username_right_text":


### PR DESCRIPTION
This PR should add Steem.Ninja (https://steemit.com/introduceyourself/@steem.ninja/steem-ninja-account-sign-ups-with-credit-card-and-referral-reward-system) to the paid signup model.

Steem.Ninja is an app provided by Oracle-D to buy steem accounts with a credit card. A new account currently costs 2$ and comes along with a 15SP delegation for 90 days.