### PR TITLE
Added Steemwallet.app to paid account-creation sources

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -4,6 +4,7 @@ const CHECKPOINTS = {
     paid_signup_clicked_blocktrades: 'paid_signup_clicked_blocktrades',
     paid_signup_clicked_anonsteem: 'paid_signup_clicked_anonsteem',
     paid_signup_clicked_steemconnect: 'paid_signup_clicked_steemconnect',
+    paid_signup_clicked_steemwalletapp: 'paid_signup_clicked_steemwalletapp',    
     free_signup_chosen: 'free_signup_chosen',
     username_chosen: 'username_chosen',
     email_submitted: 'email_submitted',
@@ -35,6 +36,10 @@ const checkpoints = [
     {
         human: 'Clicked steemconnect',
         symbol: CHECKPOINTS.paid_signup_clicked_steemconnect,
+    },
+    {
+        human: 'Clicked steemwalletapp',
+        symbol: CHECKPOINTS.paid_signup_clicked_steemwalletapp,
     },
     {
         human: 'Pressed "Sign up for free"',

--- a/src/components/Form/Signup/SignupOptions.js
+++ b/src/components/Form/Signup/SignupOptions.js
@@ -99,7 +99,23 @@ const SignupOptions = ({
                 <p>
                     <FormattedMessage id="signup_options_blocktrades" />
                 </p>
-
+                 <a
+                    className="external-link"
+                    href="https://steemwallet.app"
+                    onClick={() => {
+                        logCheckpoint(
+                            CHECKPOINTS.paid_signup_clicked_steemwalletapp
+                        );
+                    }}
+                >
+                    <Button type="primary" ghost htmlType="button">
+                        SteemWallet.app
+                        <Icon type="link" />
+                    </Button>
+                </a>
+                <p>
+                    <FormattedMessage id="signup_options_steemwalletapp" />
+                </p>
                 <a
                     className="external-link"
                     href="https://anon.steem.network/"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,9 +139,11 @@
     "signup_options_blocktrades":
         "A third-party tool that accepts Bitcoin, Ethereum, Litecoin, STEEM and more. Blocktrades charges it's own small fee.",
     "signup_options_anonsteem":
-        "A third-party tool that accepts Bitcoin, Litecoin and STEEM. AnonSteem also charges it's own a small fee.",
+        "A third-party tool that accepts Bitcoin, Litecoin and STEEM. AnonSteem also charges it's own small fee.",
     "signup_options_steemconnect":
         "Try this option if you already have a Steem account and want to pay to set up a new account for yourself or a friend.",
+    "signup_options_steemwalletapp":
+        "An open-source mobile wallet utilising in-app payments for 1-tap account creation. SteemWallet charges it's own small fees.",
     "signup_options_disclaimer":
         "Note: Steemit, Inc does not receive any money from paid accounts.",
     "signup_username_right_text":


### PR DESCRIPTION
Steemwallet.app now offers in-app account creation through 1-click in-app payments for iOS and Android devices. The app is fully opensource and available via the regular appstores.